### PR TITLE
Make sure the routes file list is ordered

### DIFF
--- a/lib/rails-routes/railtie.rb
+++ b/lib/rails-routes/railtie.rb
@@ -2,7 +2,7 @@ module RailsRoutes
   class Railtie < Rails::Railtie
     initializer "rails_routes" do
       app = Rails.application
-      routes = Dir[Rails.root.join("config/routes/**/*.rb").to_s]
+      routes = Dir[Rails.root.join("config/routes/**/*.rb").to_s].sort
       app.routes_reloader.paths.unshift(*routes)
       app.config.paths["config/routes.rb"].concat(routes)
     end


### PR DESCRIPTION
Because among the matched routes, the one that is created before the other will be of the highest priority, so  we need to be clear about which file is loaded before the other file in order to avoid different behavior on different platform.